### PR TITLE
fix: link rot (get seq package from web.archive.org)

### DIFF
--- a/assemble_synApps
+++ b/assemble_synApps
@@ -595,7 +595,10 @@ if (exists($modules{SNCSEQ}))
 	rmtree("seq-${FILTER_TAG}");
 	say $RELEASE "SNCSEQ=\$(SUPPORT)/seq-${FILTER_TAG}";
 	
-	`curl -LO https://www-csr.bessy.de/control/SoftDist/sequencer/releases/seq-${TAG}.tar.gz`;
+	# www-csr.bessy.de is dead :-(
+	# get the seq package from web.archive.org until there is a working host again
+	# `curl -LO https://www-csr.bessy.de/control/SoftDist/sequencer/releases/seq-${TAG}.tar.gz`;
+	`curl -LO http://web.archive.org/web/20230128080042/http://www-csr.bessy.de/control/SoftDist/sequencer/releases/seq-${TAG}.tar.gz`;
 	
 	`tar zxf seq-${TAG}.tar.gz`;
 	move("seq-${TAG}", "seq-${FILTER_TAG}");


### PR DESCRIPTION
`www-csr.bessy.de` is down, so `assemble_synApps.sh` doesn't work anymore.

As a workaround, this PR changes the URL for a web.archive.org based one.

Not sure if there is a official repository for `seq`. To get it from `web.archive.org` may not be a permanent solution, but at least it makes the script work again.

See also https://github.com/EPICS-synApps/support/pull/27