### PR TITLE
Some fixes for building synApps on a fresh Ubuntu 22 successfully

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,90 @@
+name: build
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [main pullrequest0]
+  pull_request:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    # convert this to a matrix if builds differ between platforms
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+    steps:
+
+      - name: Install required packages
+        run: |
+          sudo apt-get install -y git build-essential curl libusb-dev libusb-1.0-0-dev re2c x11proto-dev libx11-dev libxext-dev
+
+      # get & build EPICS first
+      - name: Restore cached EPICS
+        id: cache-epics
+        uses: actions/cache/restore@v4
+        with:
+          path: epics-base
+          key: ${{ runner.os }}-epics-base
+
+      - name: Check out epics
+        if: steps.cache-epics.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: epics-base/epics-base
+          ref: '7.0'
+          submodules: recursive
+          path: epics-base
+
+      - name: Build EPICS
+        if: steps.cache-epics.outputs.cache-hit != 'true'
+        run: |
+          cd epics-base
+          make distclean
+          make
+
+      - name: Cache EPICS
+        uses: actions/cache/save@v4
+        with:
+          path: epics-base
+          key: ${{ steps.cache-epics.outputs.cache-primary-key }}
+
+      - name: Check out assemble_synApps
+        uses: actions/checkout@v4
+        with:
+          path: assemble_synApps
+
+      - name: Build synApps
+        run: |
+          ./assemble_synApps/assemble_synApps --base="$(pwd)/epics-base" --dir="$(pwd)/synapps" 2>&1 | tee assemble.log
+          cd synapps/support
+          make 2>&1 | tee ../../make.log
+
+      - name: Check Galil created files
+        run: |
+            cd synapps/support
+            echo Listing all files in Galil-* directory
+            find Galil-* -type f
+
+      - name: Store logs as artifacts
+        if: success() || failure() # always store the logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_logs
+          path: |
+            assemble.log
+            make.log
+
+      - name: Store build results as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: synApps+epics
+          path: |
+            assemble_synApps
+            epics-base
+            synapps

--- a/README.md
+++ b/README.md
@@ -4,14 +4,45 @@ synApps assemble script
 Used to pull a user-defined set of EPICS modules at given tags and package them into a
 single synApps directory that will build with a single 'make' command.
 
-## usage
+## Usage
 
 The script can be called by itself and will use a default set of modules and tags to
 build the synApps release. There are also a set of command line options to customize
 the setup as needed. Or otherwise, the script itself is rather easy to find and replace
 default values.
 
-### Command Line Interface
+## Requirements (Linux)
+
+Additional packages to install on Ubuntu 22.04:
+
+    apt install -y git build-essential curl libusb-dev libusb-1.0-0-dev re2c x11proto-dev libx11-dev libxext-dev
+
+## Example Setup on Linux
+
+1. Create a base folder for synApps/EPICS setup:
+
+        mkdir -p ~/epics
+
+2. Get & build EPICS base
+
+       cd ~/epics
+       git clone --recursive -b 7.0 https://github.com/epics-base/epics-base.git base
+       cd base && make distclean && make -j8
+
+3. Get synApps
+
+       cd ~/epics
+       git clone https://github.com/BAMresearch/EPICS-synApps-assemble.git assemble_synApps
+
+4. Build synApps
+
+       cd ~/epics
+       # make sure the source tree belongs to the current user, avoids errors around this
+       sudo chown -R $(id -un).$(id -gn) .
+       # assemble synApps which builds everything finally
+       ./assemble_synApps/assemble_synApps --base="$(realpath base)" --dir="$(realpath synapps)"
+
+## Command Line Interface
 
 The command line options that assemble_synApps recognizes are:
 
@@ -22,7 +53,7 @@ The command line options that assemble_synApps recognizes are:
 * --check
 * --help
 
-#### config
+### config
 
 The config option is used to provide a separate file with a list of modules and their tags.
 This file should be arranged with each definition on their own line and in the form of
@@ -34,19 +65,19 @@ module isn't defined in the config file provided, it will not use any default va
 module just will not be downloaded.
 
 
-#### dir
+### dir
 
 The dir option is used to define the name of the synApps directory to be created. All modules
 will be downloaded into the folder structure synApps_dir_name/support.
 
 
-#### base
+### base
 
 The base option is used to define the location of the installation of EPICS base on your system
 that synApps will link against.
 
 
-#### set
+### set
 
 The set option is used to make individual changes to the module definitions you will be using.
 Each usage of the `--set` option should be followed by a string in the form of
@@ -57,7 +88,7 @@ already exist, or will overwrite an existing definition. This works regardless o
 using the default module definitions or if you have a config file.
 
 
-#### check
+### check
 
 The check option is a sanity check before you fully run the script. It will display the values of
 all the module definitions that it will be downloading.

--- a/assemble_synApps
+++ b/assemble_synApps
@@ -66,7 +66,7 @@ if ($releasefile eq "default")
 	$modules{'DXPSITORO'} = 'R1-3';
 	$modules{'DEVIOCSTATS'} = '3.1.16';
 	$modules{'ETHERIP'} = 'ether_ip-3-3';
-	$modules{'GALIL'} = 'V3-6';
+	$modules{'GALIL'} = 'R3-6-85';
 	$modules{'IP'} = 'R2-22';
 	$modules{'IPAC'} = '2.16';
 	$modules{'IP330'} = 'R2-10';
@@ -256,7 +256,7 @@ $module_info{DXP}           = {group => "epics-modules",         repo => "dxp"};
 $module_info{DXPSITORO}     = {group => "epics-modules",         repo => "dxpSITORO"};
 $module_info{DEVIOCSTATS}   = {group => "epics-modules",         repo => "iocStats"};
 $module_info{ETHERIP}       = {group => "epics-modules",         repo => "ether_ip"};
-$module_info{GALIL}         = {group => "motorapp",              repo => "Galil-3-0"};
+$module_info{GALIL}         = {group => "motorapp",              repo => "Galil"};
 $module_info{IP}            = {group => "epics-modules",         repo => "ip"};
 $module_info{IPAC}          = {group => "epics-modules",         repo => "ipac"};
 $module_info{IP330}         = {group => "epics-modules",         repo => "ip330"};
@@ -514,32 +514,10 @@ if (exists($modules{GALIL}))
 	
 	$FILTER_TAG =~ s/V//g;
 	
-	chdir "Galil-3-0-$modules{GALIL}";
+	chdir "Galil-$modules{GALIL}";
 	
-	copy_recur("${FILTER_TAG}/.", "./");
-	rmtree("${FILTER_TAG}");
+	copy("./config/GALILRELEASE", "./configure/RELEASE.local");
 
-	system("mv config/* configure/");
-	rmtree("config");
-	copy("./configure/GALILRELEASE", "./configure/RELEASE.local");
-
-	add_line('-include $(TOP)/../RELEASE.local', "./configure/RELEASE");
-	add_line('-include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local', "./configure/RELEASE");
-	add_line('-include $(TOP)/configure/RELEASE.local', "./configure/RELEASE");
-	add_line('CONFIG = $(EPICS_BASE)/configure', "./configure/CONFIG");
-	add_line('include $(TOP)/configure/RELEASE', "./configure/CONFIG");
-	add_line('include $(CONFIG)/CONFIG', "./configure/CONFIG");
-	add_line('include $(EPICS_BASE)/configure/RULES_TOP', "./configure/RULES_TOP");
-	add_line('include $(CONFIG)/RULES', "./configure/RULES");
-	
-	do_substitution("\QLIBRARY_IOC += GalilSupport\E", "LIBRARY_IOC_Linux \+= GalilSupport\nLIBRARY_IOC_WIN32 += GalilSupport", "GalilSup/src/Makefile");
-	do_substitution("PROD_IOC = GalilTest", "PROD_IOC_Linux = GalilTest\nPROD_IOC_WIN32 = GalilTest", "GalilTestApp/src/Makefile");
-	system("mkdir -p dbd && cp GalilSup/src/GalilSupport.dbd dbd/");
-	
-	if (exists($modules{SNCSEQ}))
-	{
-		do_substitution("asyn motor calc sscan autosave busy", "asyn motor calc sscan autosave busy seq pv", "GalilTestApp/src/Makefile");
-	}
 	
 	chdir "..";
 }
@@ -737,12 +715,7 @@ say $RELEASE "-include \$(SUPPORT)/configure/RELEASE.local";
 say $RELEASE "-include \$(SUPPORT)/configure/RELEASE.\$(EPICS_HOST_ARCH).local";
 close($RELEASE);
 
+# Make RELEASE files for support modules consistent
 system("make release"); # system() forwards output and errors of the command
-
-if (exists($modules{GALIL}))
-{
-	# copy updated RELEASE.local with correct paths to expected GALILRELEASE file
-	chdir "Galil-3-0-$modules{GALIL}/configure";
-	copy("RELEASE.local", "GALILRELEASE");
-	chdir "../..";
-}
+# Start the build
+system("make");

--- a/assemble_synApps
+++ b/assemble_synApps
@@ -202,11 +202,6 @@ sub get_repo {
 		
 		chdir "$FOLDER_NAME";
 		`git checkout -q $TAG`;
-		chdir "..";
-		
-		say $REL "$RELEASE_NAME=\$(SUPPORT)/$FOLDER_NAME";
-		
-		print "\n";
 	}
 	else
 	{
@@ -218,12 +213,10 @@ sub get_repo {
 		`git stash -q`;
 		`git clean -fdx`;
 		`git checkout -q $TAG`;
-		chdir "..";
-		
-		say $REL "$RELEASE_NAME=\$(SUPPORT)/$FOLDER_NAME";
-		
-		print "\n";
 	}
+	chdir "..";
+	say $REL "$RELEASE_NAME=\$(SUPPORT)/$FOLDER_NAME";
+	print "\n";
 }
 
 

--- a/assemble_synApps
+++ b/assemble_synApps
@@ -66,7 +66,7 @@ if ($releasefile eq "default")
 	$modules{'DXPSITORO'} = 'R1-3';
 	$modules{'DEVIOCSTATS'} = '3.1.16';
 	$modules{'ETHERIP'} = 'ether_ip-3-3';
-	$modules{'GALIL'} = 'V3-5';
+	$modules{'GALIL'} = 'V3-6';
 	$modules{'IP'} = 'R2-22';
 	$modules{'IPAC'} = '2.16';
 	$modules{'IP330'} = 'R2-10';

--- a/assemble_synApps
+++ b/assemble_synApps
@@ -584,7 +584,7 @@ if (exists($modules{MEASCOMP}))
 		
 		system("./configure --prefix=${PWD}");
 		system("make");
-		`make install || true`;
+		`sudo make install || true`;
 		
 		unlink("../configure/CONFIG_SITE.local");
 		add_line("USR_LDFLAGS+=-L${PWD}/lib", "../configure/CONFIG_SITE.local");

--- a/assemble_synApps
+++ b/assemble_synApps
@@ -518,15 +518,27 @@ if (exists($modules{GALIL}))
 	
 	copy_recur("${FILTER_TAG}/.", "./");
 	rmtree("${FILTER_TAG}");
-	
-	copy("./config/GALILRELEASE", "./configure/RELEASE.local");
+
+	system("mv config/* configure/");
+	rmtree("config");
+	copy("./configure/GALILRELEASE", "./configure/RELEASE.local");
 
 	add_line('-include $(TOP)/../RELEASE.local', "./configure/RELEASE");
 	add_line('-include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local', "./configure/RELEASE");
 	add_line('-include $(TOP)/configure/RELEASE.local', "./configure/RELEASE");
+	add_line('CONFIG = $(EPICS_BASE)/configure', "./configure/CONFIG");
+	add_line('include $(TOP)/configure/RELEASE', "./configure/CONFIG");
+	add_line('include $(CONFIG)/CONFIG', "./configure/CONFIG");
+	add_line('include $(EPICS_BASE)/configure/RULES_TOP', "./configure/RULES_TOP");
+	do_substitution('/configure/RULES', '/configure/RULES_TOP', "GalilTestApp/src/Makefile");
+	do_substitution('/configure/RULES', '/configure/RULES_TOP', "GalilTestApp/Db/Makefile");
+	do_substitution('/configure/RULES', '/configure/RULES_TOP', "GalilSup/Db/Makefile");
+	do_substitution('/configure/RULES', '/configure/RULES_TOP', "GalilSup/src/Makefile");
+
 	
 	do_substitution("\QLIBRARY_IOC += GalilSupport\E", "LIBRARY_IOC_Linux \+= GalilSupport\nLIBRARY_IOC_WIN32 += GalilSupport", "GalilSup/src/Makefile");
 	do_substitution("PROD_IOC = GalilTest", "PROD_IOC_Linux = GalilTest\nPROD_IOC_WIN32 = GalilTest", "GalilTestApp/src/Makefile");
+	system("mkdir -p dbd && cp GalilSup/src/GalilSupport.dbd dbd/");
 	
 	if (exists($modules{SNCSEQ}))
 	{
@@ -730,3 +742,11 @@ say $RELEASE "-include \$(SUPPORT)/configure/RELEASE.\$(EPICS_HOST_ARCH).local";
 close($RELEASE);
 
 system("make release"); # system() forwards output and errors of the command
+
+if (exists($modules{GALIL}))
+{
+	# copy updated RELEASE.local with correct paths to expected GALILRELEASE file
+	chdir "Galil-3-0-$modules{GALIL}/configure";
+	copy("RELEASE.local", "GALILRELEASE");
+	chdir "../..";
+}

--- a/assemble_synApps
+++ b/assemble_synApps
@@ -214,6 +214,7 @@ sub get_repo {
 		`git clean -fdx`;
 		`git checkout -q $TAG`;
 	}
+	system("mkdir -p configure; echo 'EPICS_BASE=$EPICS_BASE' >> configure/RELEASE.local");
 	chdir "..";
 	say $REL "$RELEASE_NAME=\$(SUPPORT)/$FOLDER_NAME";
 	print "\n";

--- a/assemble_synApps
+++ b/assemble_synApps
@@ -530,11 +530,7 @@ if (exists($modules{GALIL}))
 	add_line('include $(TOP)/configure/RELEASE', "./configure/CONFIG");
 	add_line('include $(CONFIG)/CONFIG', "./configure/CONFIG");
 	add_line('include $(EPICS_BASE)/configure/RULES_TOP', "./configure/RULES_TOP");
-	do_substitution('/configure/RULES', '/configure/RULES_TOP', "GalilTestApp/src/Makefile");
-	do_substitution('/configure/RULES', '/configure/RULES_TOP', "GalilTestApp/Db/Makefile");
-	do_substitution('/configure/RULES', '/configure/RULES_TOP', "GalilSup/Db/Makefile");
-	do_substitution('/configure/RULES', '/configure/RULES_TOP', "GalilSup/src/Makefile");
-
+	add_line('include $(CONFIG)/RULES', "./configure/RULES");
 	
 	do_substitution("\QLIBRARY_IOC += GalilSupport\E", "LIBRARY_IOC_Linux \+= GalilSupport\nLIBRARY_IOC_WIN32 += GalilSupport", "GalilSup/src/Makefile");
 	do_substitution("PROD_IOC = GalilTest", "PROD_IOC_Linux = GalilTest\nPROD_IOC_WIN32 = GalilTest", "GalilTestApp/src/Makefile");

--- a/assemble_synApps
+++ b/assemble_synApps
@@ -727,8 +727,6 @@ say $RELEASE "-include \$(SUPPORT)/RELEASE.local";
 say $RELEASE "-include \$(SUPPORT)/RELEASE.\$(EPICS_HOST_ARCH).local";
 say $RELEASE "-include \$(SUPPORT)/configure/RELEASE.local";
 say $RELEASE "-include \$(SUPPORT)/configure/RELEASE.\$(EPICS_HOST_ARCH).local";
-
-
 close($RELEASE);
 
-`make release`;
+system("make release"); # system() forwards output and errors of the command

--- a/assemble_synApps
+++ b/assemble_synApps
@@ -66,7 +66,7 @@ if ($releasefile eq "default")
 	$modules{'DXPSITORO'} = 'R1-3';
 	$modules{'DEVIOCSTATS'} = '3.1.16';
 	$modules{'ETHERIP'} = 'ether_ip-3-3';
-	$modules{'GALIL'} = 'V3-6';
+	$modules{'GALIL'} = 'V3-5';
 	$modules{'IP'} = 'R2-22';
 	$modules{'IPAC'} = '2.16';
 	$modules{'IP330'} = 'R2-10';


### PR DESCRIPTION
- except for the xxx template which complains about `No rule to make target '../../../lib/linux-x86_64/libGalilSupport.a', needed by 'xxx'.` (but I can't find any rule, reference or existence of a _libGalilSupport_ in the Galil module while it builds without errors)
- [for reference] assuming the following build dependencies were installed beforehand  `sudo apt-get install -y git build-essential curl libusb-dev libusb-1.0-0-dev re2c x11proto-dev libx11-dev libxext-dev`
  - A full example can be found in the [associated Github Action](https://github.com/BAMresearch/EPICS-synApps-assemble/blob/main/.github/workflows/build.yml)